### PR TITLE
Fix indentation in hierarchical lists

### DIFF
--- a/godown.go
+++ b/godown.go
@@ -303,10 +303,10 @@ func walk(node *html.Node, w io.Writer, nest int, option *Option) {
 				walk(c, &buf, 1, option)
 				if lines := strings.Split(strings.TrimSpace(buf.String()), "\n"); len(lines) > 0 {
 					for i, l := range lines {
-						if i > 0 || nest > 0 {
+						if i > 0 {
 							fmt.Fprint(w, "\n")
 						}
-						fmt.Fprint(w, strings.Repeat("    ", nest)+strings.TrimSpace(l))
+						fmt.Fprint(w, strings.Repeat("    ", nest)+l)
 					}
 					fmt.Fprint(w, "\n")
 				}

--- a/testdata/test018.html
+++ b/testdata/test018.html
@@ -1,16 +1,17 @@
 <ul>
-    <li>nest1
-        <ol>
-            <li>nest1-1</li>
-            <li>nest1-2</li>
-            <li>nest1-3</li>
-            <li>nest1-4</li>
-        </ol>
-    </li>
-    <li>nest2
+    <li>nest1</li>
+    <ol>
+        <li>nest1-1</li>
+        <li>nest1-2</li>
+        <li>nest1-3</li>
         <ul>
-            <li>nest-1</li>
-            <li>nest-2</li>
+            <li>nest1-3-1</li>
         </ul>
-    </li>
+        <li>nest1-4</li>
+    </ol>
+    <li>nest2</li>
+    <ul>
+        <li>nest2-1</li>
+        <li>nest2-2</li>
+    </ul>
 </ul>

--- a/testdata/test018.md
+++ b/testdata/test018.md
@@ -1,10 +1,10 @@
 * nest1
-1. nest1-1
-2. nest1-2
-3. nest1-3
-4. nest1-4
-
+    1. nest1-1
+    2. nest1-2
+    3. nest1-3
+        * nest1-3-1
+    4. nest1-4
 * nest2
-* nest-1
-* nest-2
+    * nest2-1
+    * nest2-2
 


### PR DESCRIPTION
Change the way lists are converted, respecting nested lists. If the original HTML looked like this:

```html
<ul>
  <li>item1</li>
  <ul>
    <li>subitem1</li>
  </ul>
  <li>item2</li>
</ul>
```
Converted markdown will respect the nested structure and output result with 4 spaces indenting the nested list:
```
* item1
    * subitem1
* item2
```