### PR TITLE
Guess the lang of pre>code blocks based on the class

### DIFF
--- a/godown.go
+++ b/godown.go
@@ -42,16 +42,14 @@ func attr(node *html.Node, key string) string {
 // Gets the language of a code block based on the class
 // See: https://spec.commonmark.org/0.29/#example-112
 func langFromClass(node *html.Node) string {
-	var lang string
-
 	if node.FirstChild == nil || strings.ToLower(node.FirstChild.Data) != "code" {
-		return lang
+		return ""
 	}
 
 	fChild := node.FirstChild
 	classes := strings.Split(attr(fChild, "class"), " ")
 	if len(classes) == 0 {
-		return lang
+		return ""
 	}
 
 	prefix := "language-"
@@ -59,10 +57,10 @@ func langFromClass(node *html.Node) string {
 		if !strings.HasPrefix(class, prefix) {
 			continue
 		}
-		lang = strings.TrimPrefix(class, prefix)
+		return strings.TrimPrefix(class, prefix)
 	}
 
-	return lang
+	return ""
 }
 
 func br(node *html.Node, w io.Writer, option *Option) {

--- a/godown.go
+++ b/godown.go
@@ -47,7 +47,7 @@ func langFromClass(node *html.Node) string {
 	}
 
 	fChild := node.FirstChild
-	classes := strings.Split(attr(fChild, "class"), " ")
+	classes := strings.Fields(attr(fChild, "class"))
 	if len(classes) == 0 {
 		return ""
 	}

--- a/godown.go
+++ b/godown.go
@@ -39,6 +39,32 @@ func attr(node *html.Node, key string) string {
 	return ""
 }
 
+// Gets the language of a code block based on the class
+// See: https://spec.commonmark.org/0.29/#example-112
+func langFromClass(node *html.Node) string {
+	var lang string
+
+	if node.FirstChild == nil || strings.ToLower(node.FirstChild.Data) != "code" {
+		return lang
+	}
+
+	fChild := node.FirstChild
+	classes := strings.Split(attr(fChild, "class"), " ")
+	if len(classes) == 0 {
+		return lang
+	}
+
+	prefix := "language-"
+	for _, class := range classes {
+		if !strings.HasPrefix(class, prefix) {
+			continue
+		}
+		lang = strings.TrimPrefix(class, prefix)
+	}
+
+	return lang
+}
+
 func br(node *html.Node, w io.Writer, option *Option) {
 	node = node.PrevSibling
 	if node == nil {
@@ -254,7 +280,7 @@ func walk(node *html.Node, w io.Writer, nest int, option *Option) {
 				br(c, w, option)
 				var buf bytes.Buffer
 				pre(c, &buf, option)
-				var lang string
+				var lang string = langFromClass(c)
 				if option != nil && option.GuessLang != nil {
 					if guess, err := option.GuessLang(buf.String()); err == nil {
 						lang = guess

--- a/godown_test.go
+++ b/godown_test.go
@@ -78,7 +78,7 @@ def do_something():
 func TestGuessLangFromClass(t *testing.T) {
 	var buf bytes.Buffer
 	err := Convert(&buf, strings.NewReader(`
-<pre><code class="language-python">def do_something():
+<pre><code class="foo bar language-python">def do_something():
   pass
 </code></pre>
 	`), nil)

--- a/godown_test.go
+++ b/godown_test.go
@@ -75,6 +75,22 @@ def do_something():
 	}
 }
 
+func TestGuessLangFromClass(t *testing.T) {
+	var buf bytes.Buffer
+	err := Convert(&buf, strings.NewReader(`
+<pre><code class="language-python">def do_something():
+  pass
+</code></pre>
+	`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "```python\ndef do_something():\n  pass\n```\n\n\n"
+	if buf.String() != want {
+		t.Errorf("\nwant:\n%s}}}\ngot:\n%s}}}\n", want, buf.String())
+	}
+}
+
 func TestGuessLangBq(t *testing.T) {
 	var buf bytes.Buffer
 	err := Convert(&buf, strings.NewReader(`


### PR DESCRIPTION
When converting from markdown to HTML, the language of a fenced code block is often represented according to [this convention](https://spec.commonmark.org/0.29/#example-112)

This PR uses that class to infer the language of a fenced code block