### PR TITLE
make delimiters wrap around non-whitespace

### DIFF
--- a/godown_test.go
+++ b/godown_test.go
@@ -110,6 +110,20 @@ func TestGuessLangBq(t *testing.T) {
 	}
 }
 
+func TestWhiteSpaceDelimiter(t *testing.T) {
+	var buf bytes.Buffer
+	err := Convert(&buf, strings.NewReader(
+		`<strong> foo bar </strong>`,
+	), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := " **foo bar** \n"
+	if buf.String() != want {
+		t.Errorf("\nwant:\n%q}}}\ngot:\n%q}}}\n", want, buf.String())
+	}
+}
+
 func TestScript(t *testing.T) {
 	var buf bytes.Buffer
 	err := Convert(&buf, strings.NewReader(`


### PR DESCRIPTION
In the spec, <https://spec.commonmark.org/0.29/#delimiter-run>

* A  left-flanking delimiter run should not followed by Unicode whitespace
* A  right-flanking delimiter run should not preceded by Unicode whitespace

This will wrap the delimiter (such as **) around the non-whitespace contents, but preserve the whitespace
