### PR TITLE
Ignore images without a src attribute

### DIFF
--- a/godown.go
+++ b/godown.go
@@ -375,7 +375,11 @@ func walk(node *html.Node, w io.Writer, nest int, option *Option) {
 				walk(c, w, nest, option)
 				fmt.Fprint(w, "\n\n")
 			case "img":
-				fmt.Fprint(w, "!["+attr(c, "alt")+"]("+attr(c, "src")+")")
+				src := attr(c, "src")
+				alt := attr(c, "alt")
+				if src != "" {
+					fmt.Fprintf(w, "![%s](%s)\n\n", alt, src)
+				}
 			case "hr":
 				br(c, w, option)
 				fmt.Fprint(w, "\n---\n\n")

--- a/godown.go
+++ b/godown.go
@@ -378,7 +378,7 @@ func walk(node *html.Node, w io.Writer, nest int, option *Option) {
 				src := attr(c, "src")
 				alt := attr(c, "alt")
 				if src != "" {
-					fmt.Fprintf(w, "![%s](%s)\n\n", alt, src)
+					fmt.Fprintf(w, "![%s](%s)", alt, src)
 				}
 			case "hr":
 				br(c, w, option)

--- a/godown_test.go
+++ b/godown_test.go
@@ -124,6 +124,20 @@ func TestWhiteSpaceDelimiter(t *testing.T) {
 	}
 }
 
+func TestEmptyImageSrc(t *testing.T) {
+	var buf bytes.Buffer
+	err := Convert(&buf, strings.NewReader(
+		`<img src="" alt="foo bar">`,
+	), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "\n"
+	if buf.String() != want {
+		t.Errorf("\nwant:\n%q}}}\ngot:\n%q}}}\n", want, buf.String())
+	}
+}
+
 func TestScript(t *testing.T) {
 	var buf bytes.Buffer
 	err := Convert(&buf, strings.NewReader(`


### PR DESCRIPTION
Instead of creating an image such as `![alt text]()`, this will ignore images that do not have a src attribute.