### PR TITLE
Make sure there are no new lines in link text

### DIFF
--- a/godown.go
+++ b/godown.go
@@ -276,9 +276,14 @@ func walk(node *html.Node, w io.Writer, nest int, option *Option) {
 		case html.ElementNode:
 			switch strings.ToLower(c.Data) {
 			case "a":
-				fmt.Fprint(w, "[")
-				walk(c, w, nest, option)
-				fmt.Fprint(w, "]("+attr(c, "href")+")")
+				// Links are invalid in markdown if the link text extends beyond a single line
+				// So we render the contents and strip any spaces
+				// Especially useful when an image is used as a link
+				var buf bytes.Buffer
+				walk(c, &buf, nest, option)
+				inner := strings.TrimSpace(buf.String())
+				href := attr(c, "href")
+				fmt.Fprintf(w, "[%s](%s)", inner, href)
 			case "b", "strong":
 				aroundNonWhitespace(c, w, nest, option, "**", "**")
 			case "i", "em":

--- a/godown.go
+++ b/godown.go
@@ -278,12 +278,8 @@ func walk(node *html.Node, w io.Writer, nest int, option *Option) {
 			case "a":
 				// Links are invalid in markdown if the link text extends beyond a single line
 				// So we render the contents and strip any spaces
-				// Especially useful when an image is used as a link
-				var buf bytes.Buffer
-				walk(c, &buf, nest, option)
-				inner := strings.TrimSpace(buf.String())
 				href := attr(c, "href")
-				fmt.Fprintf(w, "[%s](%s)", inner, href)
+				aroundNonWhitespace(c, w, nest, option, "[", fmt.Sprintf("](%s)", href))
 			case "b", "strong":
 				aroundNonWhitespace(c, w, nest, option, "**", "**")
 			case "i", "em":

--- a/godown_test.go
+++ b/godown_test.go
@@ -146,7 +146,7 @@ func TestBlockLink(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "[![foo bar](https://example.com/img)](https://example.org)\n"
+	want := "[![foo bar](https://example.com/img)](https://example.org)\n\n"
 	if buf.String() != want {
 		t.Errorf("\nwant:\n%q}}}\ngot:\n%q}}}\n", want, buf.String())
 	}

--- a/godown_test.go
+++ b/godown_test.go
@@ -138,6 +138,20 @@ func TestEmptyImageSrc(t *testing.T) {
 	}
 }
 
+func TestBlockLink(t *testing.T) {
+	var buf bytes.Buffer
+	err := Convert(&buf, strings.NewReader(
+		`<a href="https://example.org"><img src="https://example.com/img" alt="foo bar"><div></div></a>`,
+	), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "[![foo bar](https://example.com/img)](https://example.org)\n"
+	if buf.String() != want {
+		t.Errorf("\nwant:\n%q}}}\ngot:\n%q}}}\n", want, buf.String())
+	}
+}
+
 func TestScript(t *testing.T) {
 	var buf bytes.Buffer
 	err := Convert(&buf, strings.NewReader(`


### PR DESCRIPTION
Links are invalid in markdown if the link text extends beyond a single line
So we render the contents and strip any spaces
This prevents problems when new lines are added by empty divs
