### PR TITLE
Preserve spaces except in lists

### DIFF
--- a/godown.go
+++ b/godown.go
@@ -361,10 +361,11 @@ func walk(node *html.Node, w io.Writer, nest int, option *Option) {
 				}
 			case "ul", "ol":
 				br(c, w, option)
-				var buf bytes.Buffer
 
 				var newOption = option.Clone()
 				newOption.TrimSpace = true
+
+				var buf bytes.Buffer
 				walk(c, &buf, 1, newOption)
 				if lines := strings.Split(strings.TrimSpace(buf.String()), "\n"); len(lines) > 0 {
 					for i, l := range lines {
@@ -376,14 +377,18 @@ func walk(node *html.Node, w io.Writer, nest int, option *Option) {
 					fmt.Fprint(w, "\n")
 				}
 			case "li":
-				br(c, w, option)
+				// To prevent trimming space inside the list items
+				var newOption = option.Clone()
+				newOption.TrimSpace = false
+
+				br(c, w, newOption)
 				if isChildOf(c, "ul") {
 					fmt.Fprint(w, "* ")
 				} else if isChildOf(c, "ol") {
 					n++
 					fmt.Fprint(w, fmt.Sprintf("%d. ", n))
 				}
-				walk(c, w, nest, option)
+				walk(c, w, nest, newOption)
 				fmt.Fprint(w, "\n")
 			case "h1", "h2", "h3", "h4", "h5", "h6":
 				br(c, w, option)

--- a/testdata/test023.html
+++ b/testdata/test023.html
@@ -1,0 +1,1 @@
+<a href="many">many</a> <a href="more">more</a> <a href="examples">examples</a>

--- a/testdata/test023.md
+++ b/testdata/test023.md
@@ -1,0 +1,1 @@
+[many](many) [more](more) [examples](examples)


### PR DESCRIPTION
Previously, we were preserving spaces only in formatted text, however it seems we should always preserve spaces.

I ran into this edge case (which I have added as a test case) where if there are multiple links right after each other, because it is a blank space between them, that space is trimmed.

```html
<a href="many">many</a> <a href="more">more</a> <a href="examples">examples</a>
```

becomes

```
[many](many)[more](more)[examples](examples)
```

But always preserving spaces broke other test cases, such as the lists.

So I reversed the option to be `TrimSpaces` which is only done when parsing list items.