### PR TITLE
Handle <s> tag as strikethrough

### DIFF
--- a/godown.go
+++ b/godown.go
@@ -319,7 +319,7 @@ func walk(node *html.Node, w io.Writer, nest int, option *Option) {
 				aroundNonWhitespace(c, w, nest, option, "**", "**")
 			case "i", "em":
 				aroundNonWhitespace(c, w, nest, option, "_", "_")
-			case "del":
+			case "del", "s":
 				aroundNonWhitespace(c, w, nest, option, "~~", "~~")
 			case "br":
 				br(c, w, option)

--- a/testdata/test009.html
+++ b/testdata/test009.html
@@ -1,1 +1,1 @@
-<del>Yes, We Can</del>
+<del>Yes, We Can</del> <s>No, We Can't</s>

--- a/testdata/test009.md
+++ b/testdata/test009.md
@@ -1,1 +1,1 @@
-~~Yes, We Can~~
+~~Yes, We Can~~ ~~No, We Can't~~


### PR DESCRIPTION
Properly handle the [`<s>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s) tag as a strikethrough.