### PR TITLE
fix bug with URL encoded image src

### DIFF
--- a/godown.go
+++ b/godown.go
@@ -470,7 +470,7 @@ func walk(node *html.Node, w io.Writer, nest int, option *Option) {
 					full = fmt.Sprintf("![%s](%s %q)", alt, src, title)
 				}
 
-				fmt.Fprintf(w, full)
+				fmt.Fprint(w, full)
 			case "hr":
 				br(c, w, option)
 				fmt.Fprint(w, "\n---\n\n")


### PR DESCRIPTION
Using `fmt.Fprintf` instead of `fmt.Fprint` made URL encoded image src values as formatting tokens which broke images such as `![](http://example.com/undici%20external%20calls)`