### PR TITLE
Add option to use asterix for italics

### DIFF
--- a/godown.go
+++ b/godown.go
@@ -288,6 +288,11 @@ func walk(node *html.Node, w io.Writer, nest int, option *Option) {
 		fmt.Fprint(w, text)
 	}
 
+	italicChar := "_"
+	if option.ItalicsAsterix {
+		italicChar = "*"
+	}
+
 	n := 0
 	for c := node.FirstChild; c != nil; c = c.NextSibling {
 		switch c.Type {
@@ -319,7 +324,7 @@ func walk(node *html.Node, w io.Writer, nest int, option *Option) {
 			case "b", "strong":
 				aroundNonWhitespace(c, w, nest, option, "**", "**")
 			case "i", "em":
-				aroundNonWhitespace(c, w, nest, option, "_", "_")
+				aroundNonWhitespace(c, w, nest, option, italicChar, italicChar)
 			case "del", "s":
 				aroundNonWhitespace(c, w, nest, option, "~~", "~~")
 			case "br":
@@ -524,6 +529,7 @@ type Option struct {
 	TrimSpace      bool
 	CustomRules    []CustomRule
 	IgnoreComments bool
+	ItalicsAsterix bool // Used to know if to use _ or * for italics
 	doNotEscape    bool // Used to know if to escape certain characters
 	customRulesMap map[string]WalkFunc
 }

--- a/godown_test.go
+++ b/godown_test.go
@@ -294,3 +294,34 @@ func TestCustomOverwriteRules(t *testing.T) {
 		t.Errorf("\nwant:\n%s}}}\ngot:\n%s}}}\n", want, buf.String())
 	}
 }
+
+func TestItalicStyle(t *testing.T) {
+	var buf bytes.Buffer
+	from := `<em>Hello world</em>`
+
+	// The default mode
+	err := Convert(&buf, strings.NewReader(from), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := `_Hello world_
+`
+	if buf.String() != want {
+		t.Errorf("\nwant:\n%s}}}\ngot:\n%s}}}\n", want, buf.String())
+	}
+
+	buf.Reset()
+
+	// Change the italic style to asterix
+	err = Convert(&buf, strings.NewReader(from), &Option{ItalicsAsterix: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want = `*Hello world*
+`
+	if buf.String() != want {
+		t.Errorf("\nwant:\n%s}}}\ngot:\n%s}}}\n", want, buf.String())
+	}
+}


### PR DESCRIPTION
I've added this option because [goldmark](https://github.com/yuin/goldmark) and perhaps other Markdown Parsers do not play well with mixed styles when trying to do bold & italics (e.g. `***hello***`)